### PR TITLE
add-parameter-for-preloaded-vm-enable

### DIFF
--- a/deploy/group_vars/servers.yml
+++ b/deploy/group_vars/servers.yml
@@ -10,45 +10,46 @@ use_postgres: false
 # only update vmamster from repo
 update: false
 
-# config name from install_vmmaster/templates/
-vmmaster_config_name: all
-
 # postgres params
 postgres_user: vmmaster
 postgres_password: vmmaster
 postgres_db: vmmaster_db
 postgres_host: localhost
 
+# config name from install_vmmaster/templates/
+change_vmmaster_config: true
+vmmaster_config_name: all
+
 # config params from install_vmmaster/templates/
-vmmaster_config:
-    basedir: os.path.dirname(os.path.realpath(__file__))
-    port: 9000
+vmmaster_basedir: os.path.dirname(os.path.realpath(__file__))
+vmmaster_port: 9000
 
-    clones_dir: "clones"
-    origins_dir: "origins"
-    session_dir: "session"
+vmmaster_clones_dir: "clones"
+vmmaster_origins_dir: "origins"
+vmmaster_session_dir: "session"
 
-    # screenshots
-    screenshots_dir: "screenshots"
-    screenshots_days: 7
+# screenshots
+vmmaster_screenshots_dir: "screenshots"
+vmmaster_screenshots_days: 7
 
-    # logging
-    log_dir: "log"
-    log_size: 5242880
+# logging
+vmmaster_log_dir: "log"
+vmmaster_log_size: 5242880
 
-    # vm related stuff
-    max_vm_count: 2
-    preloaded:
-      - {type: "ubuntu-14.04-x64", count: 1}
-    session_timeout: 360
-    ping_timeout: 180
+# vm related stuff
+vmmaster_max_vm_count: 2
+vmmaster_use_preloaded: false
+vmmaster_preloaded:
+  - {type: "ubuntu-14.04-x64", count: 1}
+vmmaster_session_timeout: 360
+vmmaster_ping_timeout: 180
 
-    # additional logging
-    graylog: ('logserver', 12201)
+# additional logging
+vmmaster_graylog: ('logserver', 12201)
 
-    # graphite
-    graphite: ('graphite', 2003)
+# graphite
+vmmaster_graphite: ('graphite', 2003)
 
-    # selenium
-    selenium_port: "4455"
-    vmmaster_agent_port: "9000"
+# selenium
+vmmaster_selenium_port: "4455"
+vmmaster_agent_port: "9000"

--- a/deploy/roles/install_postgres/tasks/main.yml
+++ b/deploy/roles/install_postgres/tasks/main.yml
@@ -20,5 +20,5 @@
   sudo_user: postgres
 
 - name: install postgres | create postgres user
-  postgresql_user: db={{postgres_user}} name={{postgres_user}} password={{postgres_password}} priv=ALL
+  postgresql_user: db={{postgres_db}} name={{postgres_user}} password={{postgres_password}} priv=ALL
   sudo_user: postgres

--- a/deploy/roles/install_vmmaster/tasks/main.yml
+++ b/deploy/roles/install_vmmaster/tasks/main.yml
@@ -4,7 +4,8 @@
   when: update
 
 - name: install vmmaster | install vmmaster with pip
-  pip: name='git+https://github.com/2gis/vmmaster.git@{{vmmaster_version}}#egg=vmmaster' extra_args='-U'
+#  pip: name='git+https://github.com/2gis/vmmaster.git@{{vmmaster_version}}#egg=vmmaster' extra_args='-U'
+  shell: sudo pip install -U git+https://github.com/2gis/vmmaster.git@{{vmmaster_version}}#egg=vmmaster
 
 - name: install vmmaster | vmmaster initialize
   shell: "echo {{vmmaster_path}} | vmmaster init"
@@ -12,7 +13,7 @@
 
 - name: install vmmaster | apply special config.py in vmmaster directory
   template: src={{vmmaster_config_name}} dest={{vmmaster_path}}/config.py mode=0644
-  when: vmmaster_config_name != ""
+  when: vmmaster_config_name != "" and change_vmmaster_config
 
 - name:
   file: path={{item.path}} owner=vmmaster group={{item.group}} mode={{item.mod}} state={{item.state}}

--- a/deploy/roles/install_vmmaster/templates/all
+++ b/deploy/roles/install_vmmaster/templates/all
@@ -2,43 +2,43 @@ import os
 
 
 class Config(object):
-    BASEDIR = {{vmmaster_config.basedir}}
-    PORT = {{vmmaster_config.port}}
+    BASEDIR = {{vmmaster_basedir}}
+    PORT = {{vmmaster_port}}
 
 {% if use_postgres %}
     DATABASE = "postgresql://{{postgres_user}}:{{postgres_password}}@{{postgres_host}}/{{postgres_db}}"
 {% else %}
     DATABASE = "sqlite:///app.db"
-    {% endif %}
+{% endif %}
 
-    CLONES_DIR = BASEDIR + "/{{vmmaster_config.clones_dir}}"
-    ORIGINS_DIR = BASEDIR + "/{{vmmaster_config.origins_dir}}"
-    SESSION_DIR = BASEDIR + "/{{vmmaster_config.session_dir}}"
+    CLONES_DIR = BASEDIR + "/{{vmmaster_clones_dir}}"
+    ORIGINS_DIR = BASEDIR + "/{{vmmaster_origins_dir}}"
+    SESSION_DIR = BASEDIR + "/{{vmmaster_session_dir}}"
 
     # screenshots
-    SCREENSHOTS_DIR = BASEDIR + "/{{vmmaster_config.screenshots_dir}}"
-    SCREENSHOTS_DAYS = {{vmmaster_config.screenshots_days}}
+    SCREENSHOTS_DIR = BASEDIR + "/{{vmmaster_screenshots_dir}}"
+    SCREENSHOTS_DAYS = {{vmmaster_screenshots_days}}
 
     # logging
-    LOG_DIR = BASEDIR + "/{{vmmaster_config.log_dir}}"
-    LOG_SIZE = {{vmmaster_config.log_size}}
+    LOG_DIR = BASEDIR + "/{{vmmaster_log_dir}}"
+    LOG_SIZE = {{vmmaster_log_size}}
 
     # vm related stuff
-    MAX_VM_COUNT = {{vmmaster_config.max_vm_count}}
+    MAX_VM_COUNT = {{vmmaster_max_vm_count}}
     PRELOADED = {
-{% for vm in vmmaster_config.preloaded %}
-        # "{{vm.type}}": {{vm.count}},
+{% for vm in vmmaster_preloaded if vmmaster_use_preloaded %}
+        "{{vm.type}}": {{vm.count}},
 {% endfor %}
     }
-    SESSION_TIMEOUT = {{vmmaster_config.session_timeout}}
-    PING_TIMEOUT = {{vmmaster_config.ping_timeout}}
+    SESSION_TIMEOUT = {{vmmaster_session_timeout}}
+    PING_TIMEOUT = {{vmmaster_ping_timeout}}
 
     # additional logging
-    # GRAYLOG = {{vmmaster_config.graylog}}
+    # GRAYLOG = {{vmmaster_graylog}}
 
     # graphite
-    # GRAPHITE = {{vmmaster_config.graphite}}
+    # GRAPHITE = {{vmmaster_graphite}}
 
     # selenium
-    SELENIUM_PORT = {{vmmaster_config.selenium_port}}
-    VMMASTER_AGENT_PORT = {{vmmaster_config.vmmaster_agent_port}}
+    SELENIUM_PORT = {{vmmaster_selenium_port}}
+    VMMASTER_AGENT_PORT = {{vmmaster_agent_port}}

--- a/functional_tests/functional_tests.py
+++ b/functional_tests/functional_tests.py
@@ -53,4 +53,5 @@ class TestCase(unittest.TestCase):
 
 
 if __name__ == "__main__":
-    unittest.TextTestRunner().run(unittest.TestLoader().loadTestsFromTestCase(TestCase))
+    results = unittest.TextTestRunner().run(unittest.TestLoader().loadTestsFromTestCase(TestCase))
+    if not results.wasSuccessful(): exit(1)


### PR DESCRIPTION
- Возможность через host_vars/file конфиг включать/выключать использование preloaded-машин в config.py
- Теперь можно выключить перезапись config.py, если нужно оставить дефолтным
- Конфиг теперь плоский и его параметры можно переопределять в host_vars/name
