### PR TITLE
Add foreign keys for log_steps tables

### DIFF
--- a/vmmaster/alembic/versions/4ec1ca506d1f_add_foreign_keys.py
+++ b/vmmaster/alembic/versions/4ec1ca506d1f_add_foreign_keys.py
@@ -1,0 +1,37 @@
+"""add foreign keys
+
+Revision ID: 4ec1ca506d1f
+Revises: f26e5c5e347
+Create Date: 2015-03-19 11:34:16.695193
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '4ec1ca506d1f'
+down_revision = '1eb29cd1981'
+
+from alembic import op
+
+
+def upgrade():
+    op.create_foreign_key(name="fk_vmmaster_log_step_to_session",
+                          source="vmmaster_log_steps",
+                          referent="sessions",
+                          local_cols=["session_id"],
+                          remote_cols=["id"],
+                          ondelete='CASCADE')
+    op.create_foreign_key(name="fk_session_log_step_to_vmmaster_log_step",
+                          source="session_log_steps",
+                          referent="vmmaster_log_steps",
+                          local_cols=["vmmaster_log_step_id"],
+                          remote_cols=["id"],
+                          ondelete='CASCADE')
+
+
+def downgrade():
+    op.drop_constraint(name="fk_vmmaster_log_step_to_session",
+                       table_name="vmmaster_log_steps",
+                       type_="foreignkey")
+    op.drop_constraint(name="fk_session_log_step_to_vmmaster_log_step",
+                       table_name="session_log_steps",
+                       type_="foreignkey")

--- a/vmmaster/cleanup.py
+++ b/vmmaster/cleanup.py
@@ -97,10 +97,6 @@ def delete_session_data(session, db_session=None):
     outdated_screenshots_count += len(screenshots)
 
     rm(screenshots)
-    for logstep in session_logsteps:
-        db_session.delete(logstep)
-    for logstep in vmmaster_logsteps:
-        db_session.delete(logstep)
     db_session.delete(session)
     db_session.commit()
     try:

--- a/vmmaster/core/db/models.py
+++ b/vmmaster/core/db/models.py
@@ -1,6 +1,6 @@
 # coding: utf-8
 
-from sqlalchemy import Column, Integer, Sequence, String, Float, Enum
+from sqlalchemy import Column, Integer, Sequence, String, Float, Enum, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
 
 
@@ -21,7 +21,7 @@ class VmmasterLogStep(Base):
     __tablename__ = 'vmmaster_log_steps'
 
     id = Column(Integer, Sequence('vmmaster_log_steps_id_seq'),  primary_key=True)
-    session_id = Column(Integer)
+    session_id = Column(Integer, ForeignKey('sessions.id', ondelete='CASCADE'))
     control_line = Column(String)
     body = Column(String)
     screenshot = Column(String)
@@ -32,7 +32,7 @@ class SessionLogStep(Base):
     __tablename__ = 'session_log_steps'
 
     id = Column(Integer, Sequence('session_log_steps_id_seq'),  primary_key=True)
-    vmmaster_log_step_id = Column(Integer)
+    vmmaster_log_step_id = Column(Integer, ForeignKey('vmmaster_log_steps.id', ondelete='CASCADE'))
     control_line = Column(String)
     body = Column(String)
     time = Column(Float)

--- a/vmmaster/migrations.py
+++ b/vmmaster/migrations.py
@@ -15,7 +15,7 @@ script = ScriptDirectory.from_config(alembic_cfg)
 
 
 def run(connection_string):
-    revision = "1eb29cd1981"
+    revision = "4ec1ca506d1f"
     alembic_cfg.set_main_option("sqlalchemy.url", connection_string)
     try:
         command.upgrade(alembic_cfg, revision)


### PR DESCRIPTION
Шаги vmmaster_log_steps и session_log_steps теперь удаляются каскадно вместе с сессией.
