### PR TITLE
Fix vmmaster_cleanup performance issue

### DIFF
--- a/vmmaster/alembic/versions/382f554a8fe8_add_indexes_for_foreign_keys.py
+++ b/vmmaster/alembic/versions/382f554a8fe8_add_indexes_for_foreign_keys.py
@@ -1,0 +1,22 @@
+"""add indexes for foreign keys
+
+Revision ID: 382f554a8fe8
+Revises: f26e5c5e347
+Create Date: 2015-03-24 11:27:22.240108
+
+"""
+
+revision = '382f554a8fe8'
+down_revision = '4ec1ca506d1f'
+
+from alembic import op
+
+
+def upgrade():
+    op.create_index('vmmaster_log_steps_fkey_idx', 'vmmaster_log_steps', ['session_id'])
+    op.create_index('session_log_steps_fkey_idx', 'session_log_steps', ['vmmaster_log_step_id'])
+
+
+def downgrade():
+    op.drop_index('vmmaster_log_steps_fkey_idx')
+    op.drop_index('session_log_steps_fkey_idx')

--- a/vmmaster/core/db/models.py
+++ b/vmmaster/core/db/models.py
@@ -2,18 +2,18 @@
 
 from sqlalchemy import Column, Integer, Sequence, String, Float, Enum, ForeignKey
 from sqlalchemy.ext.declarative import declarative_base
-
+from sqlalchemy.orm import relationship
 
 Base = declarative_base()
 
 
-class Session(Base):
-    __tablename__ = 'sessions'
+class SessionLogStep(Base):
+    __tablename__ = 'session_log_steps'
 
-    id = Column(Integer, Sequence('session_id_seq'),  primary_key=True)
-    status = Column('status', Enum('unknown', 'running', 'succeed', 'failed', name='status', native_enum=False))
-    name = Column(String)
-    error = Column(String)
+    id = Column(Integer, Sequence('session_log_steps_id_seq'),  primary_key=True)
+    vmmaster_log_step_id = Column(Integer, ForeignKey('vmmaster_log_steps.id', ondelete='CASCADE'))
+    control_line = Column(String)
+    body = Column(String)
     time = Column(Float)
 
 
@@ -26,13 +26,15 @@ class VmmasterLogStep(Base):
     body = Column(String)
     screenshot = Column(String)
     time = Column(Float)
+    agent_steps = relationship(SessionLogStep, backref="vmmaster_log_step", passive_deletes=True)
 
 
-class SessionLogStep(Base):
-    __tablename__ = 'session_log_steps'
+class Session(Base):
+    __tablename__ = 'sessions'
 
-    id = Column(Integer, Sequence('session_log_steps_id_seq'),  primary_key=True)
-    vmmaster_log_step_id = Column(Integer, ForeignKey('vmmaster_log_steps.id', ondelete='CASCADE'))
-    control_line = Column(String)
-    body = Column(String)
+    id = Column(Integer, Sequence('session_id_seq'),  primary_key=True)
+    status = Column('status', Enum('unknown', 'running', 'succeed', 'failed', name='status', native_enum=False))
+    name = Column(String)
+    error = Column(String)
     time = Column(Float)
+    session_steps = relationship(VmmasterLogStep, backref="session", passive_deletes=True)

--- a/vmmaster/migrations.py
+++ b/vmmaster/migrations.py
@@ -15,7 +15,8 @@ script = ScriptDirectory.from_config(alembic_cfg)
 
 
 def run(connection_string):
-    revision = "4ec1ca506d1f"
+    revision = "382f554a8fe8"
+
     alembic_cfg.set_main_option("sqlalchemy.url", connection_string)
     try:
         command.upgrade(alembic_cfg, revision)


### PR DESCRIPTION
Add indexes for foreign keys in vmmaster_log_steps and session_log_steps.
Add backrefs in models.
Refactor cleanup algorithm: removing whole directories, cascade deleting.
