### PR TITLE
Threaded waiting vm activate for creatind and rebuilding vm

### DIFF
--- a/vmmaster/core/virtual_machine/virtual_machines_pool.py
+++ b/vmmaster/core/virtual_machine/virtual_machines_pool.py
@@ -18,7 +18,16 @@ class VirtualMachinesPool(object):
 
     @classmethod
     def remove_vm(cls, vm):
-        cls.using.remove(vm)
+        if vm in list(cls.using):
+            try:
+                cls.using.remove(vm)
+            except ValueError:
+                pass
+        if vm in list(cls.pool):
+            try:
+                cls.pool.remove(vm)
+            except ValueError:
+                pass
 
     @classmethod
     def add_vm(cls, vm, to=None):

--- a/vmmaster/webdriver/commands.py
+++ b/vmmaster/webdriver/commands.py
@@ -5,6 +5,7 @@ import time
 from flask import Request
 
 from ..core.utils import network_utils
+from ..webdriver.helpers import check_to_exist_ip
 from ..core.config import config
 from ..core.logger import log
 from ..core.exceptions import CreationException
@@ -75,7 +76,7 @@ def startup_script(session):
 
 def ping_vm(session):
     # ping ip:port
-    ip = session.virtual_machine.ip
+    ip = check_to_exist_ip(session.virtual_machine)
     port = config.SELENIUM_PORT
     timeout = config.PING_TIMEOUT
     start = time.time()

--- a/vmmaster/webdriver/helpers.py
+++ b/vmmaster/webdriver/helpers.py
@@ -14,7 +14,7 @@ from flask.ctx import _request_ctx_stack
 
 import commands
 
-from ..core.exceptions import SessionException, ConnectionError
+from ..core.exceptions import SessionException, ConnectionError, CreationException
 from ..core.sessions import RequestHelper
 from ..core.config import config
 from ..core.logger import log
@@ -187,6 +187,20 @@ def get_vm():
     delayed_vm = q.enqueue(desired_caps)
     while delayed_vm.vm is None:
         time.sleep(0.1)
+
+
+def check_to_exist_ip(vm, tries=10, timeout=5):
+    from time import sleep
+    i = 0
+    while True:
+        if vm.ip is not None:
+            return vm.ip
+        else:
+            if i > tries:
+                raise CreationException('Error: VM %s have not ip address' % vm.name)
+            i += 1
+            log.info('IP is %s for VM %s, wait for %ss. before next try...' % (vm.ip, vm.name, timeout))
+            sleep(timeout)
 
 
 def get_session(desired_caps):


### PR DESCRIPTION
Создание новой виртуалки:
- запрос на создание оправляется в openstack, не блокирует дальнейшее создание сессии
- сессия стартует сразу, но ждет пока у виртуалки появится ip и начинает его пинговать

Ребилд виртуалки:
- запрос на ребилд оправляется в openstack, не блокирует дальнейшее завершение текущей сессии

Добавлена обработка ошибок openstack при удалении/ребилде виртуалок.
Метод VirtualMachinePool.remove_vm теперь универсальный, удаляет машину из обоих пулов, т.е. pool и using, в связи с этим поправлен OpenstackClone и KVMClone
