### PR TITLE
avalibility-zone-for-vm-in-openstack

### DIFF
--- a/deploy/group_vars/servers.yml
+++ b/deploy/group_vars/servers.yml
@@ -60,6 +60,7 @@ openstack_username: "user"
 openstack_password: "password"
 openstack_tenant_name: "test"
 openstack_tenant_id: "id"
+openstack_zone_for_vm_create: ""
 
 vmmaster_vm_check: "False"
 vmmaster_vm_check_frequency: 1800

--- a/deploy/roles/install_vmmaster/templates/all
+++ b/deploy/roles/install_vmmaster/templates/all
@@ -48,6 +48,7 @@ class Config(object):
     OPENSTACK_PASSWORD = "{{openstack_password}}"
     OPENSTACK_TENANT_NAME = "{{openstack_tenant_name}}"
     OPENSTACK_TENANT_ID = "{{openstack_tenant_id}}"
+    OPENSTACK_ZONE_FOR_VM_CREATE = "{{openstack_zone_for_vm_create}}"
 
     VM_CHECK = {{vmmaster_vm_check}}
     VM_CHECK_FREQUENCY = {{vmmaster_vm_check_frequency}}

--- a/vmmaster/core/virtual_machine/clone.py
+++ b/vmmaster/core/virtual_machine/clone.py
@@ -218,8 +218,18 @@ class OpenstackClone(Clone):
                                                                                   self.image,
                                                                                   self.flavor))
 
+        kwargs = {
+            'name': self.name,
+            'image': self.image,
+            'flavor': self.flavor,
+            'nics': [{'net-id': self.network_id}]
+        }
+
+        if bool(config.OPENSTACK_ZONE_FOR_VM_CREATE):
+            kwargs.update({'availability_zone': config.OPENSTACK_ZONE_FOR_VM_CREATE})
+
         try:
-            self.nova_client.servers.create(name=self.name, image=self.image, flavor=self.flavor, nics=[{'net-id': self.network_id}])
+            self.nova_client.servers.create(**kwargs)
         except Exception as e:
             log.info("Creating error: %s" % e)
         self._wait_for_activated_service()

--- a/vmmaster/home/config.py
+++ b/vmmaster/home/config.py
@@ -41,6 +41,7 @@ class Config(object):
     OPENSTACK_PASSWORD = "password"
     OPENSTACK_TENANT_NAME = "test"
     OPENSTACK_TENANT_ID = ""
+    OPENSTACK_ZONE_FOR_VM_CREATE = ""
 
     VM_CHECK = False
     VM_CHECK_FREQUENCY = 1800


### PR DESCRIPTION
Добавлена возможность через конфиг выбирать, в какой зоне vmmaster будет создавать виртуалки(т.е. на какой группе нод)
Если по дефолту задан пустой строкой, то будет создавать в зоне по умолчанию, которую сам openstack проставит.
