### PR TITLE
filter-by-prefix-in-vm-platform

### DIFF
--- a/deploy/group_vars/servers.yml
+++ b/deploy/group_vars/servers.yml
@@ -61,6 +61,7 @@ openstack_password: "password"
 openstack_tenant_name: "test"
 openstack_tenant_id: "id"
 openstack_zone_for_vm_create: ""
+openstack_platform_name_prefix: "origin-"
 
 vmmaster_vm_check: "False"
 vmmaster_vm_check_frequency: 1800

--- a/deploy/roles/install_vmmaster/templates/all
+++ b/deploy/roles/install_vmmaster/templates/all
@@ -49,6 +49,7 @@ class Config(object):
     OPENSTACK_TENANT_NAME = "{{openstack_tenant_name}}"
     OPENSTACK_TENANT_ID = "{{openstack_tenant_id}}"
     OPENSTACK_ZONE_FOR_VM_CREATE = "{{openstack_zone_for_vm_create}}"
+    OPENSTACK_PLATFORM_NAME_PREFIX = "{{openstack_platform_name_prefix}}"
 
     VM_CHECK = {{vmmaster_vm_check}}
     VM_CHECK_FREQUENCY = {{vmmaster_vm_check_frequency}}

--- a/vmmaster/core/platforms.py
+++ b/vmmaster/core/platforms.py
@@ -40,6 +40,7 @@ class OpenstackOrigin(Platform):
     def __init__(self, origin):
         self.id = origin.id
         self.name = origin.name
+        self.short_name = origin.name.split(config.OPENSTACK_PLATFORM_NAME_PREFIX)[1]
         self.min_disk = origin.min_disk
         self.min_ram = origin.min_ram
         self.flavor_name = origin.instance_type_name
@@ -87,7 +88,10 @@ class OpenstackPlatforms(PlatformsInterface):
 
     def _load_platforms(self):
         origins = [image for image in self.client.images.list()
-                   if image.status == 'active' and image.get('image_type', None) == 'snapshot']
+                   if image.status == 'active'
+                   and image.get('image_type', None) == 'snapshot'
+                   and config.OPENSTACK_PLATFORM_NAME_PREFIX in image.name]
+
         return [OpenstackOrigin(origin) for origin in origins]
 
 
@@ -105,7 +109,7 @@ class Platforms(object):
         if config.USE_KVM:
             cls.platforms.update({vm.name: vm for vm in KVMPlatforms().platforms})
         if config.USE_OPENSTACK:
-            cls.platforms.update({vm.name: vm for vm in OpenstackPlatforms().platforms})
+            cls.platforms.update({vm.short_name: vm for vm in OpenstackPlatforms().platforms})
 
         log.info("load all platforms: {}".format(str(cls.platforms)))
 

--- a/vmmaster/core/virtual_machine/clone.py
+++ b/vmmaster/core/virtual_machine/clone.py
@@ -50,7 +50,7 @@ class Clone(VirtualMachine):
 
     @property
     def name(self):
-        return "{}-clone-{}".format(self.platform, self.prefix)
+        return "{}-clone-{}".format(self.origin.name, self.prefix)
 
     def delete(self):
         raise NotImplementedError
@@ -218,13 +218,14 @@ class OpenstackClone(Clone):
 
     def __init__(self, origin, prefix):
         super(OpenstackClone, self).__init__(origin, prefix)
+        self.platform = origin.short_name
         self.nova_client = openstack_utils.nova_client()
         self.network_client = openstack_utils.neutron_client()
         self.network_id = self.get_network_id()
         self.network_name = self.get_network_name(self.network_id)
 
     def create(self):
-        log.info("creating openstack clone of {} with image={}, flavor={}".format(self.platform,
+        log.info("creating openstack clone of {} with image={}, flavor={}".format(self.name,
                                                                                   self.image,
                                                                                   self.flavor))
 
@@ -280,7 +281,7 @@ class OpenstackClone(Clone):
 
     @property
     def image(self):
-        return self.nova_client.images.find(name=self.platform)
+        return self.nova_client.images.find(name=self.origin.name)
 
     @property
     def flavor(self):

--- a/vmmaster/home/config.py
+++ b/vmmaster/home/config.py
@@ -31,7 +31,7 @@ class Config(object):
     USE_OPENSTACK = False
     OPENSTACK_MAX_VM_COUNT = 2
     OPENSTACK_PRELOADED = {
-        # "ubuntu-14.04-x64-SNAPSHOT": 1
+        # "ubuntu-14.04-x64": 1
     }
 
     OPENSTACK_AUTH_URL = "localhost"
@@ -42,6 +42,7 @@ class Config(object):
     OPENSTACK_TENANT_NAME = "test"
     OPENSTACK_TENANT_ID = ""
     OPENSTACK_ZONE_FOR_VM_CREATE = ""
+    OPENSTACK_PLATFORM_NAME_PREFIX = "origin-"
 
     VM_CHECK = False
     VM_CHECK_FREQUENCY = 1800


### PR DESCRIPTION
Для openstack фильтруем images по префиксу и типу snapshot. Пользователь в морде и в api видит короткие названия снэпшотов, внутри мы создаем виртуалки, используя полные имена images.
