### PR TITLE
Fix gelfhandler params and added comment with use logstash

### DIFF
--- a/deploy/group_vars/servers.yml
+++ b/deploy/group_vars/servers.yml
@@ -70,6 +70,7 @@ vmmaster_session_timeout: 360
 vmmaster_ping_timeout: 180
 
 # additional logging
+# sending logs into graylog2 or logstash (Graylog Extended Log Format, GELF)
 vmmaster_graylog: ('logserver', 12201)
 
 # graphite

--- a/vmmaster/core/logger.py
+++ b/vmmaster/core/logger.py
@@ -34,7 +34,7 @@ def setup_logging(logdir=None, scrnlog=True, txtlog=True, loglevel=logging.DEBUG
     log_formatter = logging.Formatter("%(asctime)s - %(levelname)-7s :: %(name)-6s :: %(message)s")
 
     if hasattr(config, 'GRAYLOG'):
-        graylog_handler = graypy.GELFHandler(config.GRAYLOG)
+        graylog_handler = graypy.GELFHandler(host=config.GRAYLOG[0], port=config.GRAYLOG[1])
         graylog_handler.setFormatter(log_formatter)
         log.addHandler(graylog_handler)
 

--- a/vmmaster/home/config.py
+++ b/vmmaster/home/config.py
@@ -51,6 +51,7 @@ class Config(object):
     PING_TIMEOUT = 180
 
     # additional logging
+    # sending logs into graylog2 or logstash (Graylog Extended Log Format, GELF)
     # GRAYLOG = ('logserver', 12201)
 
     # graphite


### PR DESCRIPTION
- graypy.GELFHandler принимает параметры host и port отдельно, а мы ему передавали tuple'ом
- logstash поддерживает отправку логов в GELF, поэтому можно не переделывать логирование под logstash. 
