### PR TITLE
Add checking limits from ostack

### DIFF
--- a/vmmaster/core/session_queue.py
+++ b/vmmaster/core/session_queue.py
@@ -44,7 +44,7 @@ class QueueWorker(Thread):
                     vm = pool.get(platform)
                     self.queue.dequeue(delayed_vm)
                     delayed_vm.vm = vm
-                elif pool.can_produce():
+                elif pool.can_produce(platform):
                     vm = pool.add(platform)
                     self.queue.dequeue(delayed_vm)
                     delayed_vm.vm = vm


### PR DESCRIPTION
Добавлена возможность проверять при создании виртуалки есть ли ресурсы в опенстек.
Каждый раз при создании проверяем наличие свободных cpu и ram для создания виртуалки. 

Так же, если в конфиге прописываем больше чем доступно в проекте в опенстеке, то используем органичения опенстека. Например, указали макс. инстансов 50, а в опенстеке только 30 выделено. 

Из pool.can_produce стал универсальным, нужная реализация берется на основании того какой тип виртуалки мы хотим создать, KVM или в Openstack
