### PR TITLE
set-log-level-through-config

### DIFF
--- a/deploy/group_vars/servers.yml
+++ b/deploy/group_vars/servers.yml
@@ -81,3 +81,5 @@ vmmaster_graphite: ('graphite', 2003)
 # selenium
 vmmaster_selenium_port: 4455
 vmmaster_agent_port: 9000
+
+log_level: "INFO"

--- a/deploy/roles/install_vmmaster/templates/all
+++ b/deploy/roles/install_vmmaster/templates/all
@@ -68,3 +68,5 @@ class Config(object):
     # selenium
     SELENIUM_PORT = {{vmmaster_selenium_port}}
     VMMASTER_AGENT_PORT = {{vmmaster_agent_port}}
+
+    LOG_LEVEL = "{{log_level}}"

--- a/integrational_tests/data/config.py
+++ b/integrational_tests/data/config.py
@@ -13,3 +13,5 @@ class Config(object):
 
     SCREENSHOTS_DIR = BASE_DIR + "/screenshots"
     SCREENSHOTS_DAYS = 7
+
+    LOG_LEVEL = "INFO"

--- a/tests/data/config.py
+++ b/tests/data/config.py
@@ -50,3 +50,5 @@ class Config(object):
 
     SELENIUM_PORT = 4455
     VMMASTER_AGENT_PORT = 9000
+
+    LOG_LEVEL = "INFO"

--- a/tests/data/config_with_preloaded.py
+++ b/tests/data/config_with_preloaded.py
@@ -52,3 +52,5 @@ class Config(object):
 
     SELENIUM_PORT = 4455
     VMMASTER_AGENT_PORT = 9000
+
+    LOG_LEVEL = "INFO"

--- a/vmmaster/core/logger.py
+++ b/vmmaster/core/logger.py
@@ -22,7 +22,10 @@ class StreamToLogger(object):
             self.logger.log(self.log_level, line.rstrip())
 
 
-def setup_logging(logdir=None, scrnlog=True, txtlog=True, loglevel=logging.DEBUG):
+def setup_logging(logdir=None, scrnlog=True, txtlog=True, loglevel=None):
+    if loglevel is None:
+        loglevel = logging.getLevelName(config.LOG_LEVEL.upper())
+
     logdir = os.path.abspath(logdir)
 
     if not os.path.exists(logdir):

--- a/vmmaster/home/config.py
+++ b/vmmaster/home/config.py
@@ -62,3 +62,5 @@ class Config(object):
     # selenium
     SELENIUM_PORT = 4455
     VMMASTER_AGENT_PORT = 9000
+
+    LOG_LEVEL = "INFO"


### PR DESCRIPTION
Уровень логов настраивается теперь через конфиг
Так же поставил INFO уровень по умолчанию, чтобы не выводились http логи от клиентов neutron, nova, glance для опенстека
