### PR TITLE
not_updated_modified_property_of_session

### DIFF
--- a/core/sessions.py
+++ b/core/sessions.py
@@ -105,6 +105,7 @@ class Session(SessionModel):
 
     def restart_timer(self):
         self.modified = datetime.now()
+        self.save()
 
     def delete(self, message=""):
         from core import endpoints


### PR DESCRIPTION
Из за этого постепенно росло время в inactivity и у долгих сессий тестов срабатывал таймаут и сессия закрывалась.
