### PR TITLE
Use threading module in run_script

### DIFF
--- a/core/sessions.py
+++ b/core/sessions.py
@@ -188,7 +188,6 @@ class Session(SessionModel):
         t.daemon = True
         t.start()
 
-        response = None
         while t.isAlive():
             yield None, None, None
 

--- a/core/utils/__init__.py
+++ b/core/utils/__init__.py
@@ -1,12 +1,10 @@
 # coding: utf-8
 
-from Queue import Queue
 import json
 import os
 import errno
 import pwd
 import grp
-import requests
 import time
 import sys
 
@@ -191,39 +189,6 @@ def to_json(result):
     except ValueError:
         log.info("Couldn't parse response content <%s>" % repr(result))
         return {}
-
-
-def make_request(request, host, port):
-        """ Make http request to some port
-            and return the response. """
-
-        # log.debug('Request: %s' % request)
-        q = Queue()
-        url = "http://%s:%s%s" % (host,
-                                  port,
-                                  request.url)
-
-        req = lambda: requests.request(method=request.method,
-                                       url=url,
-                                       headers=request.headers,
-                                       data=request.body)
-
-        t = Thread(target=getresponse, args=(req, q))
-        t.daemon = True
-        t.start()
-
-        response = None
-        while not response:
-            if not t.isAlive():
-                response = q.get()
-                if isinstance(response, Exception):
-                    log.info('Exception in thread '
-                             'during request: %s' % str(response))
-                break
-            elif t is not None:
-                t.join(0.1)
-
-        return response
 
 
 def remove_base64_screenshot(response_data):

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -185,7 +185,7 @@ class ServerMock(object):
     def stop(self):
         self._server.shutdown()
         self._server.server_close()
-        self._thread.join(1)
+        self._thread.join()
 
 
 class BaseTestCase(unittest.TestCase):

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -164,7 +164,7 @@ class TestServer(BaseTestServer):
         t.start()
         self.assertEqual(2, len(self.pool.using))
         self.assertTrue(t.isAlive())
-        t.join(0.1)
+        t.join()
 
     def test_get_non_existing_session(self):
         """

--- a/vmpool/clone.py
+++ b/vmpool/clone.py
@@ -421,4 +421,4 @@ class OpenstackClone(Clone):
         except Exception as e:
             log_pool.info(
                 "Rebuild vm %s was FAILED. %s" % (self.name, e.message))
-            self.delete()
+            self.delete(try_to_rebuild=False)


### PR DESCRIPTION
- в одной сессии используется один обьект Queue, создается один раз;
- удалил старый make_request, который сбивает с толку;
- в тестах везде сделал thread.join без параметра timeout;
- пофиксил еще один неверный вызов vm.delete;
- немного переименовал переменные в run_script и избавился от использования модуля thread.
