### PR TITLE
Move db and pool init to app

### DIFF
--- a/core/db/__init__.py
+++ b/core/db/__init__.py
@@ -9,6 +9,7 @@ from core.utils import to_thread
 from core.sessions import Session as WrappedSession
 
 from core.logger import log
+from core.config import config
 
 
 def threaded_transaction(func):
@@ -50,7 +51,10 @@ class Database(object):
             cls._instance = super(Database, cls).__new__(cls, *args, **kwargs)
         return cls._instance
 
-    def __init__(self, connection_string):
+    def __init__(self, connection_string=None):
+        if not connection_string:
+            connection_string = config.DATABASE
+
         self.engine = create_engine(connection_string,
                                     pool_size=200,
                                     max_overflow=100,
@@ -137,6 +141,3 @@ class Database(object):
         dbsession.delete(obj_to_delete)
         dbsession.commit()
         return obj_to_delete
-
-
-database = None

--- a/core/db/__init__.py
+++ b/core/db/__init__.py
@@ -3,9 +3,9 @@
 from sqlalchemy import create_engine, inspect, desc
 from sqlalchemy.orm import sessionmaker, scoped_session
 
+from core.sessions import Session
 from core.db.models import SessionLogStep, User, Platform
 from core.utils import to_thread
-
 from core.logger import log
 from core.config import config
 
@@ -65,10 +65,9 @@ class Database(object):
 
     @transaction
     def get_session(self, session_id, dbsession=None):
-        from core.sessions import Session as WrappedSession
         if not session_id:
             return None
-        return dbsession.query(WrappedSession).get(session_id)
+        return dbsession.query(Session).get(session_id)
 
     @transaction
     def get_log_steps_for_session(self, session_id, dbsession=None):

--- a/core/db/__init__.py
+++ b/core/db/__init__.py
@@ -6,8 +6,6 @@ from sqlalchemy.orm import sessionmaker, scoped_session
 from core.db.models import SessionLogStep, User, Platform
 from core.utils import to_thread
 
-from core.sessions import Session as WrappedSession
-
 from core.logger import log
 from core.config import config
 
@@ -67,6 +65,7 @@ class Database(object):
 
     @transaction
     def get_session(self, session_id, dbsession=None):
+        from core.sessions import Session as WrappedSession
         if not session_id:
             return None
         return dbsession.query(WrappedSession).get(session_id)
@@ -80,11 +79,6 @@ class Database(object):
     @transaction
     def get_step_by_id(self, log_step_id, dbsession=None):
         return dbsession.query(SessionLogStep).get(log_step_id)
-
-    @transaction
-    def get_queue(self, dbsession=None):
-        return dbsession.query(WrappedSession).filter_by(
-            status='waiting').all()
 
     @transaction
     def get_user(self, username=None, user_id=None, dbsession=None):

--- a/core/sessions.py
+++ b/core/sessions.py
@@ -1,23 +1,18 @@
 # coding: utf-8
 
 import time
-from datetime import datetime
+import requests
+
 from Queue import Queue
 from threading import Thread
+from datetime import datetime
+from flask import current_app
 
-import requests
-import logging
-requests_log = logging.getLogger("requests")
-requests_log.setLevel(logging.WARNING)
-
-from core.db.models import Session as SessionModel
+from core.db import models
 from core.config import config
 from core.logger import log
 from core.exceptions import SessionException
-
 from core.video import VNCVideoHelper
-
-from flask import current_app
 
 
 def getresponse(req, q):
@@ -65,7 +60,7 @@ class SimpleResponse:
         self.content = content
 
 
-class Session(SessionModel):
+class Session(models.Session):
     current_log_step = None
     vnc_helper = None
     take_screencast = None
@@ -183,10 +178,12 @@ class Session(SessionModel):
         q = Queue()
         url = "http://%s:%s%s" % (self.endpoint_ip, port, request.url)
 
-        req = lambda: requests.request(method=request.method,
-                                       url=url,
-                                       headers=request.headers,
-                                       data=request.data)
+        def req():
+            return requests.request(method=request.method,
+                                    url=url,
+                                    headers=request.headers,
+                                    data=request.data)
+
         t = Thread(target=getresponse, args=(req, q))
         t.daemon = True
         t.start()

--- a/install-dependencies.sh
+++ b/install-dependencies.sh
@@ -7,10 +7,10 @@ sudo add-apt-repository -y cloud-archive:icehouse
 sudo apt-get update
 
 # install kvm with libvirt
-sudo apt-get -y install qemu-kvm libvirt-bin
+sudo apt-get -y install qemu-kvm
 
 # install libvirt dependencies
-sudo apt-get -y install libvirt-dev
+sudo apt-get -y --force-yes install libvirt-dev libvirt-bin
 
 # install openstack dependencies
 sudo apt-get -y install libssl-dev libffi-dev

--- a/manage.py
+++ b/manage.py
@@ -8,15 +8,12 @@ from flask.ext.script import Manager
 from core.config import setup_config, config
 from core.utils.init import home_dir, useradd
 from core.logger import log
-from core import db
 from core.logger import setup_logging
 
 try:
     setup_config('%s/config.py' % home_dir())
-    db.database = db.Database(config.DATABASE)
 except AttributeError:
     config = None
-    db.database = None
 
 from core.utils import change_user_vmmaster
 

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -8,6 +8,7 @@ import time
 import socket
 import unittest
 
+from nose.twistedtools import reactor
 from mock import Mock, patch
 
 
@@ -225,7 +226,6 @@ def vmmaster_server_mock(port):
         'core.sessions.SessionWorker', Mock()
     ):
         from vmmaster.server import VMMasterServer
-        from nose.twistedtools import reactor
         return VMMasterServer(reactor, port)
 
 

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 import BaseHTTPServer
 import copy
 import json
@@ -8,8 +9,10 @@ import time
 import socket
 import unittest
 
-from nose.twistedtools import reactor
 from mock import Mock, patch
+from nose.twistedtools import reactor
+
+from core.utils.network_utils import get_socket
 
 
 class TimeoutException(Exception):
@@ -86,8 +89,6 @@ def vmmaster_label(address, session, label=None):
     return request("%s:%s" % address, "POST",
                    "/wd/hub/session/%s/vmmaster/vmmasterLabel" % str(session),
                    body=json.dumps({"label": label}))
-
-from core.utils.network_utils import get_socket
 
 
 def server_is_up(address, wait=5):
@@ -230,5 +231,4 @@ def vmmaster_server_mock(port):
 
 
 def request_mock(**kwargs):
-    time.sleep(2)
     return Mock(status_code=200, headers={}, content=json.dumps({'status': 0}))

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -216,7 +216,7 @@ def vmmaster_server_mock(port):
     ), patch(
         'core.connection.Virsh', Mock()
     ), patch(
-        'core.db.database', DatabaseMock()
+        'core.db.Database', DatabaseMock()
     ), patch(
         'core.utils.init.home_dir', Mock(return_value=fake_home_dir())
     ), patch(

--- a/tests/unit/test_auth.py
+++ b/tests/unit/test_auth.py
@@ -24,15 +24,10 @@ class TestWDAuthPositive(BaseTestCase):
         from core.config import setup_config
         setup_config('data/config.py')
 
-        with patch('core.network.Network', Mock()), \
-                patch('core.connection.Virsh', Mock()):
-            from vmpool.platforms import Platforms
-            cls.platform = Platforms().platforms.keys()[0]
-
     def setUp(self):
         self.desired_caps = {
             'desiredCapabilities': {
-                'platform': self.platform
+                'platform': 'test_origin_1'
             }
         }
 
@@ -129,11 +124,6 @@ class TestAPIAuthPositive(BaseTestCase):
 
         from core.config import setup_config
         setup_config('data/config.py')
-
-        with patch('core.network.Network', Mock()), \
-                patch('core.connection.Virsh', Mock()):
-            from vmpool.platforms import Platforms
-            cls.platform = Platforms().platforms.keys()[0]
 
         cls.method = "GET"
         from base64 import urlsafe_b64encode

--- a/tests/unit/test_http_proxy.py
+++ b/tests/unit/test_http_proxy.py
@@ -29,10 +29,10 @@ class TestHttpProxy(BaseTestCase):
     def tearDown(self):
         self.session.delete()
         self.ctx.pop()
-        with patch('core.db.database', Mock()):
-            self.vmmaster.app.sessions.kill_all()
-            del self.vmmaster
-            server_is_down(self.address)
+        self.vmmaster.app.sessions.kill_all()
+        self.vmmaster.app.cleanup()
+        del self.vmmaster
+        server_is_down(self.address)
 
     def test_proxy_successful(self):
         server = ServerMock(self.host, self.free_port)

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -888,7 +888,6 @@ class TestRunScriptTimeGreaterThenSessionTimeout(BaseTestCase):
             response = new_session_request(self.address, self.desired_caps)
 
         self.assertEqual(200, response.status)
-        time.sleep(2)
 
         response = get_session_request(self.address, 1)
         self.assertIn(

--- a/tests/unit/test_server.py
+++ b/tests/unit/test_server.py
@@ -36,7 +36,7 @@ class BaseTestServer(BaseTestCase):
         ), patch(
             'core.network.Network', Mock()
         ), patch(
-            'core.db.database', DatabaseMock()
+            'core.db.Database', DatabaseMock()
         ), patch(
             'core.sessions.SessionWorker', Mock()
         ):
@@ -384,16 +384,11 @@ class TestSessionWorker(BaseTestCase):
 
         from flask import Flask
         self.app = Flask(__name__)
-
-        with patch(
-            'core.connection.Virsh', Mock(),
-        ), patch(
-            'core.network.Network', Mock()
-        ):
-            from core.sessions import SessionWorker
-        self.worker = SessionWorker(self.app)
-
         self.app.sessions = Mock()
+        self.app.sessions.app = self.app
+
+        from core.sessions import SessionWorker
+        self.worker = SessionWorker(self.app.sessions)
 
     def tearDown(self):
         self.worker.stop()
@@ -429,7 +424,7 @@ class TestConnectionClose(BaseTestServer):
 
         self.desired_caps = {
             'desiredCapabilities': {
-                'platform': self.vmmaster.app.platforms.platforms.keys()[0]
+                'platform': self.pool.platforms.platforms.keys()[0]
             }
         }
 
@@ -454,9 +449,10 @@ class TestConnectionClose(BaseTestServer):
 
         self.assertEqual(0, self.pool.count())
 
-        import vmpool.virtual_machines_pool as vmp
-        with patch.object(vmp, 'pool', Mock()) as p:
-            p.has = Mock(side_effect=pool_fake_return)
+        with patch(
+            'flask.current_app.pool.has',
+            Mock(side_effect=pool_fake_return)
+        ):
             request_with_drop(self.address, self.desired_caps, None)
 
         self.assertEqual(0, self.pool.count())
@@ -466,10 +462,13 @@ class TestConnectionClose(BaseTestServer):
         - close the connection when the request is queued
         Expected: session deleted, vm deleted
         """
-        import vmpool.virtual_machines_pool as vmp
-        with patch.object(vmp, 'pool', Mock()) as p:
-            p.has = Mock(return_value=False)
-            p.can_produce = Mock(return_value=False)
+        with patch(
+            'flask.current_app.pool.has',
+            Mock(return_value=False)
+        ), patch(
+            'flask.current_app.pool.can_produce',
+            Mock(return_value=False)
+        ):
             request_with_drop(self.address, self.desired_caps, None)
 
         self.assertEqual(0, self.pool.count())
@@ -481,11 +480,13 @@ class TestConnectionClose(BaseTestServer):
         - drop request while platform is queued
         Expected: platform no more in queue
         """
-        import vmpool.virtual_machines_pool as vmp
-        with patch.object(vmp, 'pool', Mock()) as p:
-            p.has = Mock(return_value=False)
-            p.can_produce = Mock(return_value=True)
-
+        with patch(
+            'flask.current_app.pool.has',
+            Mock(return_value=False)
+        ), patch(
+            'flask.current_app.pool.can_produce',
+            Mock(return_value=True)
+        ):
             q = self.vmmaster.app.sessions.active_sessions
 
             def wait_for_platform_in_queue():
@@ -524,11 +525,11 @@ class TestConnectionClose(BaseTestServer):
             time.sleep(2)
             return vm_mock
 
-        from vmpool.virtual_machines_pool import pool
-        with patch.object(
-            pool, 'has', Mock(return_value=False)
-        ), patch.object(
-            pool, 'can_produce', Mock(return_value=True)
+        with patch(
+            'flask.current_app.pool.has',
+            Mock(return_value=False)
+        ), patch(
+            'flask.current_app.pool.can_produce', Mock(return_value=True)
         ), patch(
             'vmpool.platforms.KVMOrigin.make_clone',
             Mock(side_effect=just_sleep)
@@ -561,7 +562,8 @@ class TestServerShutdown(BaseTestServer):
 
         self.desired_caps = {
             'desiredCapabilities': {
-                'platform': self.vmmaster.app.platforms.platforms.keys()[0]
+                'platform':
+                self.vmmaster.app.pool.platforms.platforms.keys()[0]
             }
         }
 
@@ -646,7 +648,7 @@ class TestServerWithPreloadedVM(BaseTestCase):
         ), patch(
             'core.network.Network', Mock()
         ), patch(
-            'core.db.database', Mock(add=Mock(side_effect=set_primary_key))
+            'core.db.Database', Mock(add=Mock(side_effect=set_primary_key))
         ), patch.multiple(
             'core.utils.openstack_utils',
             neutron_client=Mock(return_value=Mock()),
@@ -670,14 +672,22 @@ class TestServerWithPreloadedVM(BaseTestCase):
             from vmmaster.server import VMMasterServer
             self.vmmaster = VMMasterServer(reactor, self.address[1])
 
-        self.pool = self.vmmaster.app.pool
+            self.ctx = self.vmmaster.app.app_context()
+            self.ctx.push()
+
+            self.pool = self.vmmaster.app.pool
 
         server_is_up(self.address)
 
-    @patch('core.utils.delete_file', Mock())
+    @patch(
+        'vmpool.clone.OpenstackClone._wait_for_activated_service',
+        custom_wait
+    )
     def tearDown(self):
+        self.vmmaster.app.sessions.kill_all()
         del self.vmmaster
         server_is_down(self.address)
+        self.ctx.pop()
 
     @patch('vmpool.clone.OpenstackClone.vm_has_created', new=Mock(
         __name__='vm_has_created',
@@ -732,7 +742,8 @@ class TestSessionSteps(BaseTestServer):
 
         self.desired_caps = {
             'desiredCapabilities': {
-                'platform': self.vmmaster.app.platforms.platforms.keys()[0]
+                'platform':
+                self.vmmaster.app.pool.platforms.platforms.keys()[0]
             }
         }
 
@@ -808,8 +819,6 @@ class TestSessionSteps(BaseTestServer):
 class TestRunScriptTimeGreaterThenSessionTimeout(BaseTestCase):
     def setUp(self):
         setup_config('data/config.py')
-        from core.config import config
-        config.SESSION_TIMEOUT = 1
 
         self.address = ("localhost", 9001)
 
@@ -818,7 +827,7 @@ class TestRunScriptTimeGreaterThenSessionTimeout(BaseTestCase):
         ), patch(
             'core.network.Network', Mock()
         ), patch(
-            'core.db.database', DatabaseMock()
+            'core.db.Database', DatabaseMock()
         ):
             from vmmaster.server import VMMasterServer
             self.vmmaster = VMMasterServer(reactor, self.address[1])
@@ -829,7 +838,7 @@ class TestRunScriptTimeGreaterThenSessionTimeout(BaseTestCase):
 
         self.desired_caps = {
             'desiredCapabilities': {
-                'platform': self.vmmaster.app.platforms.platforms.keys()[0]
+                'platform': self.pool.platforms.platforms.keys()[0]
             }
         }
 
@@ -862,6 +871,9 @@ class TestRunScriptTimeGreaterThenSessionTimeout(BaseTestCase):
             return_value=(200, {}, json.dumps({'sessionId': 1}))
         )
     )
+    @patch(
+        'flask.current_app.database', Mock(get_session=Mock(return_value=None))
+    )
     def test_check_timer_for_session_activity(self):
         """
         - exception while waiting endpoint
@@ -878,10 +890,7 @@ class TestRunScriptTimeGreaterThenSessionTimeout(BaseTestCase):
         self.assertEqual(200, response.status)
         time.sleep(2)
 
-        with patch(
-            'flask.current_app.database.get_session', Mock(return_value=None)
-        ):
-            response = get_session_request(self.address, 1)
+        response = get_session_request(self.address, 1)
         self.assertIn(
             "SessionException: There is no active session 1 (Unknown session)",
             response.content

--- a/tests/unit/test_vnc_recorder.py
+++ b/tests/unit/test_vnc_recorder.py
@@ -50,7 +50,7 @@ class TestVNCVideoHelper(BaseTestCase):
         ), patch(
             "core.connection.Virsh", Mock()
         ), patch(
-            'core.db.database', DatabaseMock()
+            'core.db.Database', DatabaseMock()
         ):
             from core.sessions import Session
             self.session = Session(dc=dc)

--- a/vmmaster/api/__init__.py
+++ b/vmmaster/api/__init__.py
@@ -47,11 +47,6 @@ def pool():
     return render_json(result={'pool': vmpool_helpers.get_pool()})
 
 
-@api.route('/pool_queue')
-def queue():
-    return render_json(result={'queue': vmpool_helpers.get_queue()})
-
-
 @api.route('/config', methods=['GET', 'POST'])
 def _config():
     if request.method == 'GET':

--- a/vmmaster/api/__init__.py
+++ b/vmmaster/api/__init__.py
@@ -3,7 +3,7 @@
 import json
 import helpers
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, current_app
 
 from core.logger import log
 from vmpool.api import helpers as vmpool_helpers
@@ -157,10 +157,9 @@ def get_vnc_info(session_id):
 
 @api.route('/pool/<string:endpoint_name>', methods=['DELETE'])
 def delete_vm_from_pool(endpoint_name):
-    from vmpool.virtual_machines_pool import pool
     result = "Endpoint %s not found in pool" % endpoint_name
 
-    endpoint = pool.get_by_name(endpoint_name)
+    endpoint = current_app.pool.get_by_name(endpoint_name)
 
     if endpoint:
         try:
@@ -176,11 +175,10 @@ def delete_vm_from_pool(endpoint_name):
 
 @api.route('/pool', methods=['DELETE'])
 def delete_all_vm_from_pool():
-    from vmpool.virtual_machines_pool import pool
     results = []
     failed = []
 
-    for endpoint in pool.pool + pool.using:
+    for endpoint in current_app.pool.pool + current_app.pool.using:
         try:
             endpoint.delete()
             results.append(endpoint)

--- a/vmmaster/api/helpers.py
+++ b/vmmaster/api/helpers.py
@@ -45,11 +45,11 @@ def get_screenshots(session_id, log_step_id=None):
     screenshots = []
 
     if log_step_id:
-        session_steps = [current_app.database.get_step_by_id(log_step_id)]
+        steps = [current_app.database.get_step_by_id(log_step_id)]
     else:
-        session_steps = current_app.database.get_log_steps_for_session(session_id)
+        steps = current_app.database.get_log_steps_for_session(session_id)
 
-    for log_step in session_steps:
+    for log_step in steps:
         if log_step.screenshot:
             screenshots.append(log_step.screenshot)
 

--- a/vmmaster/api/helpers.py
+++ b/vmmaster/api/helpers.py
@@ -42,13 +42,12 @@ def regenerate_user_token(user_id):
 
 
 def get_screenshots(session_id, log_step_id=None):
-    from core.db import database
     screenshots = []
 
     if log_step_id:
-        session_steps = [database.get_step_by_id(log_step_id)]
+        session_steps = [current_app.database.get_step_by_id(log_step_id)]
     else:
-        session_steps = database.get_log_steps_for_session(session_id)
+        session_steps = current_app.database.get_log_steps_for_session(session_id)
 
     for log_step in session_steps:
         if log_step.screenshot:
@@ -58,10 +57,9 @@ def get_screenshots(session_id, log_step_id=None):
 
 
 def get_screenshots_for_label(session_id, label_id):
-    from core.db import database
     steps_groups = {}
     current_label = 0
-    log_steps = database.get_log_steps_for_session(session_id)
+    log_steps = current_app.database.get_log_steps_for_session(session_id)
 
     for step in reversed(log_steps):
         if label_step(step.control_line) == 'label':

--- a/vmmaster/server.py
+++ b/vmmaster/server.py
@@ -1,20 +1,20 @@
 # coding: utf-8
 
 import time
-from http_proxy import ProxyResource, HTTPChannelWithClient
-from twisted.internet.threads import deferToThread
-from twisted.internet.defer import inlineCallbacks, Deferred, TimeoutError
+from Queue import Queue, Empty
+
 from twisted.web.wsgi import WSGIResource
 from twisted.web.server import Site
 from twisted.web.resource import Resource
-from twisted.python.threadpool import ThreadPool
 from twisted.python.failure import Failure
-from Queue import Queue, Empty
-
-from core.logger import log
-from core.config import config
+from twisted.python.threadpool import ThreadPool
+from twisted.internet.defer import inlineCallbacks, Deferred, TimeoutError
+from twisted.internet.threads import deferToThread
 
 from app import create_app
+from http_proxy import ProxyResource, HTTPChannelWithClient
+from core.logger import log
+from core.config import config
 
 
 def _block_on(d, timeout=None):

--- a/vmmaster/server.py
+++ b/vmmaster/server.py
@@ -1,24 +1,23 @@
 # coding: utf-8
 
 import time
+from http_proxy import ProxyResource, HTTPChannelWithClient
 from twisted.internet.threads import deferToThread
+from twisted.internet.defer import inlineCallbacks, Deferred, TimeoutError
 from twisted.web.wsgi import WSGIResource
 from twisted.web.server import Site
 from twisted.web.resource import Resource
-from twisted.internet import defer
 from twisted.python.threadpool import ThreadPool
-from app import create_app
+from twisted.python.failure import Failure
+from Queue import Queue, Empty
 
-from http_proxy import ProxyResource, HTTPChannelWithClient
 from core.logger import log
 from core.config import config
 
+from app import create_app
+
 
 def _block_on(d, timeout=None):
-    from Queue import Queue, Empty
-    from twisted.internet.defer import TimeoutError
-    from twisted.python.failure import Failure
-    from twisted.internet.defer import Deferred
     _q = Queue()
     if not isinstance(d, Deferred):
         return None
@@ -50,7 +49,6 @@ class VMMasterServer(object):
     def __init__(self, reactor, port):
         self.reactor = reactor
         self.app = create_app()
-
         self.thread_pool = ThreadPool(maxthreads=config.THREAD_POOL_MAX)
         self.thread_pool.start()
         wsgi_resource = WSGIResource(self.reactor, self.thread_pool, self.app)
@@ -88,7 +86,7 @@ class VMMasterServer(object):
 
         return deferToThread(wait_for, self).addBoth(lambda i: None)
 
-    @defer.inlineCallbacks
+    @inlineCallbacks
     def before_shutdown(self):
         self.app.running = False
         yield self.wait_for_end_active_sessions()

--- a/vmpool/api/helpers.py
+++ b/vmpool/api/helpers.py
@@ -4,7 +4,7 @@ from flask import current_app
 
 
 def get_platforms():
-    return current_app.platforms.info()
+    return current_app.pool.platforms.info()
 
 
 def get_pool():

--- a/vmpool/api/helpers.py
+++ b/vmpool/api/helpers.py
@@ -1,12 +1,11 @@
 # coding: utf-8
 
-from vmpool.platforms import Platforms
-from vmpool.virtual_machines_pool import pool
+from flask import current_app
 
 
 def get_platforms():
-    return Platforms.info()
+    return current_app.platforms.info()
 
 
 def get_pool():
-    return pool.info
+    return current_app.pool.info

--- a/vmpool/clone.py
+++ b/vmpool/clone.py
@@ -19,8 +19,6 @@ from core.exceptions import libvirtError, CreationException
 from core.config import config
 from core.utils import network_utils
 
-from flask import current_app
-
 
 def threaded_wait(func):
     @wraps(func)
@@ -36,10 +34,11 @@ def threaded_wait(func):
 
 
 class Clone(VirtualMachine):
-    def __init__(self, origin, prefix):
+    def __init__(self, origin, prefix, pool):
         self.uuid = '%s' % uuid4()
         self.prefix = '%s' % prefix
         self.origin = origin
+        self.pool = pool
         name = "{platform}-clone-{prefix}-{uuid}".format(
             platform=origin.name, prefix=self.prefix, uuid=self.uuid)
 
@@ -89,10 +88,10 @@ class KVMClone(Clone):
     dumpxml_file = None
     drive_path = None
 
-    def __init__(self, origin, prefix):
-        super(KVMClone, self).__init__(origin, prefix)
+    def __init__(self, origin, prefix, pool):
+        super(KVMClone, self).__init__(origin, prefix, pool)
 
-        self.network = current_app.pool.network
+        self.network = self.pool.network
         self.conn = self.network.conn
 
     def delete(self, try_to_rebuild=True):
@@ -117,7 +116,7 @@ class KVMClone(Clone):
         except ValueError, e:
             log_pool.warning(e)
             pass
-        current_app.pool.remove_vm(self)
+        self.pool.remove_vm(self)
         VirtualMachine.delete(self)
 
     def create(self):
@@ -139,12 +138,12 @@ class KVMClone(Clone):
             "Rebuilding kvm clone {clone} ({ip}, {platform})...".format(
                 clone=self.name, ip=self.ip, platform=self.platform)
         )
-        current_app.pool.remove_vm(self)
+        self.pool.remove_vm(self)
         self.delete(try_to_rebuild=False)
 
         try:
-            current_app.pool.add(
-                self.platform, self.prefix, current_app.pool.pool)
+            self.pool.add(
+                self.platform, self.prefix, self.pool.pool)
         except CreationException:
             pass
 
@@ -211,8 +210,8 @@ class KVMClone(Clone):
 
 
 class OpenstackClone(Clone):
-    def __init__(self, origin, prefix):
-        super(OpenstackClone, self).__init__(origin, prefix)
+    def __init__(self, origin, prefix, pool):
+        super(OpenstackClone, self).__init__(origin, prefix, pool)
         self.platform = origin.short_name
 
         from core.utils import openstack_utils
@@ -394,7 +393,7 @@ class OpenstackClone(Clone):
             return
 
         self.ready = False
-        current_app.pool.remove_vm(self)
+        self.pool.remove_vm(self)
         if self.check_vm_exist(self.name):
             try:
                 self.nova_client.servers.find(name=self.name).delete()
@@ -412,8 +411,8 @@ class OpenstackClone(Clone):
         log_pool.info("Rebuilding openstack {clone}".format(clone=self.name))
 
         if self.is_preloaded():
-            current_app.pool.remove_vm(self)
-            current_app.pool.pool.append(self)
+            self.pool.remove_vm(self)
+            self.pool.pool.append(self)
 
         self.ready = False
         try:

--- a/vmpool/endpoint.py
+++ b/vmpool/endpoint.py
@@ -5,9 +5,9 @@ from core.logger import log_pool
 from core.config import config
 
 from core.exceptions import PlatformException, CreationException
-
-from vmpool.virtual_machines_pool import pool
 from vmpool.platforms import Platforms
+
+from flask import current_app
 
 
 def get_platform(desired_caps):
@@ -42,7 +42,7 @@ def get_vm(desired_caps):
     for _ in generator_wait_for(
         lambda: vm, timeout=config.GET_VM_TIMEOUT
     ):
-        vm = pool.get_vm(platform)
+        vm = current_app.pool.get_vm(platform)
         if vm:
             break
 

--- a/vmpool/endpoint.py
+++ b/vmpool/endpoint.py
@@ -5,7 +5,6 @@ from core.logger import log_pool
 from core.config import config
 
 from core.exceptions import PlatformException, CreationException
-from vmpool.platforms import Platforms
 
 from flask import current_app
 
@@ -29,7 +28,7 @@ def get_platform(desired_caps):
             'Platform parameter for new endpoint not found in dc'
         )
 
-    if not Platforms.check_platform(platform):
+    if not current_app.pool.platforms.check_platform(platform):
         raise PlatformException('No such platform %s' % platform)
 
     return platform

--- a/vmpool/platforms.py
+++ b/vmpool/platforms.py
@@ -16,7 +16,7 @@ class Platform(object):
         pass
 
     @staticmethod
-    def make_clone(origin, prefix):
+    def make_clone(origin, prefix, pool):
         raise NotImplementedError
 
 
@@ -30,9 +30,9 @@ class KVMOrigin(Platform):
         self.settings = open(os.path.join(path, 'settings.xml'), 'r').read()
 
     @staticmethod
-    def make_clone(origin, prefix):
+    def make_clone(origin, prefix, pool):
         from clone import KVMClone
-        return KVMClone(origin, prefix)
+        return KVMClone(origin, prefix, pool)
 
 
 class OpenstackOrigin(Platform):
@@ -53,9 +53,9 @@ class OpenstackOrigin(Platform):
             self.flavor_name = config.OPENSTACK_DEFAULT_FLAVOR
 
     @staticmethod
-    def make_clone(origin, prefix):
+    def make_clone(origin, prefix, pool):
         from clone import OpenstackClone
-        return OpenstackClone(origin, prefix)
+        return OpenstackClone(origin, prefix, pool)
 
 
 class PlatformsInterface(object):

--- a/vmpool/virtual_machines_pool.py
+++ b/vmpool/virtual_machines_pool.py
@@ -8,9 +8,7 @@ from core.config import config
 from core.logger import log_pool
 from core.network import Network
 
-from platforms import UnlimitedCount
-
-from flask import current_app
+from vmpool.platforms import Platforms, UnlimitedCount
 
 
 class VirtualMachinesPool(object):
@@ -18,9 +16,15 @@ class VirtualMachinesPool(object):
     using = list()
     network = Network()
     lock = Lock()
+    platforms = Platforms
 
     def __str__(self):
         return str(self.pool)
+
+    def __init__(self):
+        self.platforms()
+        self.preloader = VirtualMachinesPoolPreloader(self)
+        self.preloader.start()
 
     @classmethod
     def remove_vm(cls, vm):
@@ -59,7 +63,7 @@ class VirtualMachinesPool(object):
 
     @classmethod
     def can_produce(cls, platform):
-        platform_limit = current_app.platforms.get_limit(platform)
+        platform_limit = cls.platforms.get_limit(platform)
 
         if platform_limit is UnlimitedCount:
             return True
@@ -146,9 +150,9 @@ class VirtualMachinesPool(object):
             if not cls.can_produce(platform):
                 return None
 
-            origin = current_app.platforms.get(platform)
+            origin = cls.platforms.get(platform)
             try:
-                clone = origin.make_clone(origin, prefix)
+                clone = origin.make_clone(origin, prefix, cls)
             except Exception as e:
                 log_pool.info(
                     'Exception during initializing vm object: %s' % e.message
@@ -212,11 +216,11 @@ class VirtualMachinesPool(object):
 
 
 class VirtualMachinesPoolPreloader(Thread):
-    def __init__(self, _pool):
+    def __init__(self, pool):
         Thread.__init__(self)
         self.running = True
         self.daemon = True
-        self.pool = _pool
+        self.pool = pool
 
     def run(self):
         while self.running:

--- a/vmpool/virtual_machines_pool.py
+++ b/vmpool/virtual_machines_pool.py
@@ -8,7 +8,9 @@ from core.config import config
 from core.logger import log_pool
 from core.network import Network
 
-from platforms import Platforms, UnlimitedCount
+from platforms import UnlimitedCount
+
+from flask import current_app
 
 
 class VirtualMachinesPool(object):
@@ -57,7 +59,7 @@ class VirtualMachinesPool(object):
 
     @classmethod
     def can_produce(cls, platform):
-        platform_limit = Platforms.get_limit(platform)
+        platform_limit = current_app.platforms.get_limit(platform)
 
         if platform_limit is UnlimitedCount:
             return True
@@ -144,7 +146,7 @@ class VirtualMachinesPool(object):
             if not cls.can_produce(platform):
                 return None
 
-            origin = Platforms.get(platform)
+            origin = current_app.platforms.get(platform)
             try:
                 clone = origin.make_clone(origin, prefix)
             except Exception as e:
@@ -247,6 +249,3 @@ class VirtualMachinesPoolPreloader(Thread):
         self.running = False
         self.join(1)
         log_pool.info("Preloader stopped")
-
-
-pool = VirtualMachinesPool()


### PR DESCRIPTION
- Перенес импорт внутрь метода во избежание циклических импортов, можно будет поправить позже (вынести всё из init.py например)

```
from core.sessions import Session as WrappedSession
```
- Приходится передавать ссылку на pool в клоны. Через current_app.pool получается не очень красиво (т.к. клоны создаются в том числе preloader'ом)
- платформы спрятал в pool, session_worker - в sessions.
