### PR TITLE
Dont closing session if session already closed

### DIFF
--- a/core/sessions.py
+++ b/core/sessions.py
@@ -144,6 +144,8 @@ class Session(models.Session):
             log.warn("Session %s already closed with reason %s. "
                      "In this method call was tb='%s' and reason='%s'"
                      % (self.id, self.reason, tb, reason))
+            return
+
         self.status = "failed"
         self.error = tb
         self.close(reason)


### PR DESCRIPTION
- было сделано так сначала в #179, но из за бага #184 решено было убрать return и просто логировать эти случаи
